### PR TITLE
Added rsync flags configuration option to package.  Defaults to 'avz'.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -68,6 +68,12 @@ module.exports =
       type: 'boolean'
       default: false
       order: 10
+    rsyncFlags:
+      title: 'Flags'
+      description: 'Specify rsync flags.  Default flags are \'avz\'. eg. archive, verbose, and compress file data on transfer'
+      type: 'string'
+      default: 'avz'
+      order: 11
   activate: (state)->
     atom.packages.once 'activated', =>
       @silentSyncView = new SilentSyncView

--- a/lib/silent-sync-view.coffee
+++ b/lib/silent-sync-view.coffee
@@ -29,7 +29,7 @@ class SilentSyncView extends View
     @changeStatus('Connecting')
     @rsync = new Rsync()
       .shell 'ssh'
-      .flags 'avz'
+      .flags atom.config.get('silent-sync.rsyncFlags')
       .source @root + '/'
       .destination(
         @config.username + '@' +


### PR DESCRIPTION
I needed to change the default rsync flags for my personal system because i didn't need the remote system to override the owner, group, and permissions, which a/archive does by default.  I added an option to the package configuration screen which allows for typing in your own flags.
