### PR TITLE
Changing .flags to read from @config.rsyncFlags

### DIFF
--- a/lib/silent-sync-view.coffee
+++ b/lib/silent-sync-view.coffee
@@ -29,7 +29,7 @@ class SilentSyncView extends View
     @changeStatus('Connecting')
     @rsync = new Rsync()
       .shell 'ssh'
-      .flags atom.config.get('silent-sync.rsyncFlags')
+      .flags @config.rsyncFlags
       .source @root + '/'
       .destination(
         @config.username + '@' +


### PR DESCRIPTION
Changing .flags to read from @config.rsyncFlags instead of
atom.config.get(‘silent-sync.rsyncFlags’) so that you can configure the
rsync flags in each configuration file or globally from the settings
pane.
